### PR TITLE
feat: add chat method to call directly from sarufi given bot id

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,18 @@ sarufi.deleteBot({id: BOT ID})
 
 ### Start conversation
 
-This requires us to get a bot we want to have a conversation with and calling a chat method
+There are two methods for this, i.e
+
+1. bot.chat() this requires us to get a bot we want to have a conversation with and calling a chat method
+2. sarufi.chat() this requires a required message, required bot_id and an optional chat_id as request arguments
 
 ```JS
-
+// bot.chat()
 const bot = sarufi.getBot({id: 'OUR BOT ID'})
-bot.chat({message: 'Yooh'})
+await bot.chat({message: 'Yooh'})
+
+//sarufi.chat()
+await sarufi.chat({message: 'Hey', bot_id: bot.id, chat_id: 'HEYOO',})
 
 ```
 

--- a/src/modules/instances.ts
+++ b/src/modules/instances.ts
@@ -8,6 +8,10 @@ import {
   GetBots,
   UpdateBot,
 } from '../shared/interfaces/bot.interface';
+import {
+  ChatInput,
+  ConversationResponse,
+} from '../shared/interfaces/conversation.interface';
 import { ErrorResponse } from '../shared/interfaces/shared.interface';
 import { Sarufi } from './sarufi';
 
@@ -56,4 +60,15 @@ export const deleteBot = async (
 ): Promise<ErrorResponse | DeleteBot> => {
   const sarufi = new Sarufi(data?.url, data?.token);
   return await sarufi.deleteBot(data.id);
+};
+
+export const chat = async (
+  data: ChatInput
+): Promise<ErrorResponse | ConversationResponse> => {
+  const sarufi = new Sarufi(data?.url, data?.token);
+  return await sarufi.chat({
+    message: data.message,
+    bot_id: data.bot_id,
+    chat_id: data.chat_id,
+  });
 };

--- a/src/modules/sarufi.ts
+++ b/src/modules/sarufi.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError } from 'axios';
 import { sanitizeErrorResponse } from '../shared/helpers/error.helper';
+import { id } from '../shared/helpers/id.helper';
 import { Login, LoginResponse } from '../shared/interfaces/auth.interface';
 import {
   BotRequest,
@@ -8,6 +9,7 @@ import {
   DeleteBot,
 } from '../shared/interfaces/bot.interface';
 import {
+  ChatInput,
   ConversationInput,
   ConversationResponse,
 } from '../shared/interfaces/conversation.interface';
@@ -82,6 +84,40 @@ export class Sarufi {
       bot: undefined,
       message: global?.token ? 'Unauthorized' : 'Bot ID not supplied',
     };
+  };
+
+  chat = async (
+    data: ChatInput
+  ): Promise<ConversationResponse | ErrorResponse> => {
+    if (global.token) {
+      return this.startChat(data, global.token);
+    }
+    return {
+      success: false,
+      bot: undefined,
+      message: global?.token ? 'Unauthorized' : 'Bot ID not supplied',
+    };
+  };
+  private startChat = async (
+    data: ChatInput,
+    token: string
+  ): Promise<ConversationResponse | ErrorResponse> => {
+    try {
+      const response: ConversationResponse = (
+        await axios.post(
+          `${this.BASE_DOMAIN}/conversation`,
+          {
+            ...data,
+            bot_id: data,
+            chat_id: data.chat_id || id,
+          },
+          { headers: { Authorization: `Bearer ${token}` } }
+        )
+      ).data;
+      return { ...response, success: true };
+    } catch (e) {
+      return sanitizeErrorResponse(e as AxiosError);
+    }
   };
 
   private getUserBots = async (

--- a/src/shared/interfaces/conversation.interface.ts
+++ b/src/shared/interfaces/conversation.interface.ts
@@ -26,3 +26,10 @@ export interface ConversationInput {
   message: string;
   chat_id?: string | number | unknown;
 }
+export interface ChatInput {
+  message: string;
+  bot_id: string | number;
+  chat_id?: string | number | unknown;
+  url?: string;
+  token?: string;
+}

--- a/test/modules/index.spec.ts
+++ b/test/modules/index.spec.ts
@@ -82,6 +82,27 @@ describe('Update Bot', () => {
   });
 });
 
+describe('Start chat with bot Bot', () => {
+  mocker.post(`${BASE_DOMAIN}/conversation`, (): ConversationResponse => {
+    return {
+      success: true,
+      message: ['Hi, How are you?'],
+      memory: {
+        greets: 'oya',
+      },
+      next_state: 'end',
+    };
+  });
+  it('Should start a chat with a bot', async () => {
+    const chat = await sarufi.chat({
+      message: 'Hey',
+      bot_id: 27,
+      chat_id: 'HEYOO',
+    });
+    expect(chat.success).toBe(true);
+    expect(chat?.message).toBeDefined();
+  });
+});
 describe('Delete Bot', () => {
   mocker.delete(`${BASE_DOMAIN}/chatbot/27`, (): { message: string } => {
     return { message: 'Bot deleted' };


### PR DESCRIPTION
Add chat method to call directly from sarufi given bot id, this is essential for users with one bot and hence don't have to execute the get bot method before chat

fix #25

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
